### PR TITLE
Add govprop to restore slashing blocks threshold

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -9,6 +9,7 @@ Please include a detailed description of the changes being proposed in this pull
 ## Type of Change
 
 - [ ] New Validator
+- [ ] Governance Proposal
 - [ ] Bug fix
 - [ ] Documentation update
 - [ ] Tooling enhancement

--- a/testnets/xion-testnet-1/governance-proposals/update-parameters/metadata/003-slashing-restore-blocks-threshold.json
+++ b/testnets/xion-testnet-1/governance-proposals/update-parameters/metadata/003-slashing-restore-blocks-threshold.json
@@ -1,0 +1,10 @@
+{
+  "title": "Restore x/slashing missed blocks threshold",
+  "authors": [
+    "daemon@burnt.com"
+  ],
+  "summary": "Restore x/slashing missed blocks threshold",
+  "details": "Restore x/slashing missed blocks threshold",
+  "proposal_forum_url": "",
+  "vote_option_context": ""
+}

--- a/testnets/xion-testnet-1/governance-proposals/update-parameters/proposal/003-slashing-restore-blocks-threshold.json
+++ b/testnets/xion-testnet-1/governance-proposals/update-parameters/proposal/003-slashing-restore-blocks-threshold.json
@@ -1,0 +1,19 @@
+{
+  "messages": [
+    {
+      "@type": "/cosmos.slashing.v1beta1.MsgUpdateParams",
+      "authority": "xion10d07y265gmmuvt4z0w9aw880jnsr700jctf8qc",
+      "params": {
+        "signed_blocks_window": "10000",
+        "min_signed_per_window": "0.500000000000000000",
+        "downtime_jail_duration": "600s",
+        "slash_fraction_double_sign": "0.050000000000000000",
+        "slash_fraction_downtime": "0.010000000000000000"
+      }
+    }
+  ],
+  "metadata": "https://raw.githubusercontent.com/burnt-labs/burnt-networks/main/testnets/xion-testnet-1/governance-proposals/update-parameters/metadata/003-slashing-restore-blocks-threshold.json",
+  "deposit": "10000000uxion",
+  "title": "Restore x/slashing missed blocks threshold",
+  "summary": "Restore x/slashing missed blocks threshold"
+}


### PR DESCRIPTION
## Description

Add govprop to restore slashing blocks threshold

## Type of Change

- [ ] New Validator
- [x] Governance Proposal
- [ ] Bug fix
- [ ] Documentation update
- [ ] Tooling enhancement

## Testing

- [x] I've read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [ ] I ran `make validate-genesis`
- [ ] I ran `make verify-hashes`

## Additional Information

Any additional information that you want to provide.

## Reviewers:

/assign @froch

Thank you for supporting the Burnt Networks!
