### PR TITLE
Add govprops to update `xion-testnet-1` <=> `osmo-test-5` IBC clients for `transfer` and `feeabs`

### DIFF
--- a/testnets/xion-testnet-1/governance-proposals/ibc-client-update/metadata/07-tendermint-1474-2191.json
+++ b/testnets/xion-testnet-1/governance-proposals/ibc-client-update/metadata/07-tendermint-1474-2191.json
@@ -1,0 +1,10 @@
+{
+  "title": "Update IBC client 07-tendermint-1474 -> 07-tendermint-2191",
+  "authors": [
+    "daemon@burnt.com"
+  ],
+  "summary": "Update IBC client 07-tendermint-1474 -> 07-tendermint-2191",
+  "details": "Update IBC client 07-tendermint-1474 -> 07-tendermint-2191",
+  "proposal_forum_url": "",
+  "vote_option_context": ""
+}

--- a/testnets/xion-testnet-1/governance-proposals/ibc-client-update/metadata/07-tendermint-1475-2192.json
+++ b/testnets/xion-testnet-1/governance-proposals/ibc-client-update/metadata/07-tendermint-1475-2192.json
@@ -1,0 +1,10 @@
+{
+  "title": "Update IBC client 07-tendermint-1475 -> 07-tendermint-2192",
+  "authors": [
+    "daemon@burnt.com"
+  ],
+  "summary": "Update IBC client 07-tendermint-1475 -> 07-tendermint-2192",
+  "details": "Update IBC client 07-tendermint-1475 -> 07-tendermint-2192",
+  "proposal_forum_url": "",
+  "vote_option_context": ""
+}

--- a/testnets/xion-testnet-1/governance-proposals/ibc-client-update/metadata/07-tendermint-22-108.json
+++ b/testnets/xion-testnet-1/governance-proposals/ibc-client-update/metadata/07-tendermint-22-108.json
@@ -1,0 +1,10 @@
+{
+  "title": "Update IBC client 07-tendermint-22 -> 07-tendermint-108",
+  "authors": [
+    "daemon@burnt.com"
+  ],
+  "summary": "Update IBC client 07-tendermint-22 -> 07-tendermint-108",
+  "details": "Update IBC client 07-tendermint-22 -> 07-tendermint-108",
+  "proposal_forum_url": "",
+  "vote_option_context": ""
+}

--- a/testnets/xion-testnet-1/governance-proposals/ibc-client-update/metadata/07-tendermint-23-109.json
+++ b/testnets/xion-testnet-1/governance-proposals/ibc-client-update/metadata/07-tendermint-23-109.json
@@ -1,0 +1,10 @@
+{
+  "title": "Update IBC client 07-tendermint-23 -> 07-tendermint-109",
+  "authors": [
+    "daemon@burnt.com"
+  ],
+  "summary": "Update IBC client 07-tendermint-23 -> 07-tendermint-109",
+  "details": "Update IBC client 07-tendermint-23 -> 07-tendermint-109",
+  "proposal_forum_url": "",
+  "vote_option_context": ""
+}

--- a/testnets/xion-testnet-1/governance-proposals/ibc-client-update/proposal/07-tendermint-1474-2191.json
+++ b/testnets/xion-testnet-1/governance-proposals/ibc-client-update/proposal/07-tendermint-1474-2191.json
@@ -1,0 +1,13 @@
+{
+  "messages": [
+    {
+      "@type": "/ibc.core.client.v1.ClientUpdateProposal",
+      "title": "Update IBC client 07-tendermint-1474 -> 07-tendermint-2191",
+      "description": "Update IBC client 07-tendermint-1474 -> 07-tendermint-2191",
+      "subject_client_id": "07-tendermint-1474",
+      "substitute_client_id": "07-tendermint-2191"
+    }
+  ],
+  "metadata": "https://raw.githubusercontent.com/burnt-labs/burnt-networks/main/testnets/xion-testnet-1/governance-proposals/ibc-client-updates/metadata/07-tendermint-1474-2191.json",
+  "deposit": "500000000uosmo"
+}

--- a/testnets/xion-testnet-1/governance-proposals/ibc-client-update/proposal/07-tendermint-1475-2192.json
+++ b/testnets/xion-testnet-1/governance-proposals/ibc-client-update/proposal/07-tendermint-1475-2192.json
@@ -1,0 +1,13 @@
+{
+  "messages": [
+    {
+      "@type": "/ibc.core.client.v1.ClientUpdateProposal",
+      "title": "Update IBC client 07-tendermint-1475 -> 07-tendermint-2192",
+      "description": "Update IBC client 07-tendermint-1475 -> 07-tendermint-2192",
+      "subject_client_id": "07-tendermint-1475",
+      "substitute_client_id": "07-tendermint-2192"
+    }
+  ],
+  "metadata": "https://raw.githubusercontent.com/burnt-labs/burnt-networks/main/testnets/xion-testnet-1/governance-proposals/ibc-client-updates/metadata/07-tendermint-1475-2192.json",
+  "deposit": "500000000uosmo"
+}

--- a/testnets/xion-testnet-1/governance-proposals/ibc-client-update/proposal/07-tendermint-22-108.json
+++ b/testnets/xion-testnet-1/governance-proposals/ibc-client-update/proposal/07-tendermint-22-108.json
@@ -1,0 +1,13 @@
+{
+  "messages": [
+    {
+      "@type": "/ibc.core.client.v1.ClientUpdateProposal",
+      "title": "Update IBC client 07-tendermint-22 -> 07-tendermint-108",
+      "description": "xion-testnet-1 <=> osmo-test-5",
+      "subject_client_id": "07-tendermint-22",
+      "substitute_client_id": "07-tendermint-108"
+    }
+  ],
+  "metadata": "https://raw.githubusercontent.com/burnt-labs/burnt-networks/main/testnets/xion-testnet-1/governance-proposals/ibc-client-updates/metadata/07-tendermint-22-108.json",
+  "deposit": "10000000uxion"
+}

--- a/testnets/xion-testnet-1/governance-proposals/ibc-client-update/proposal/07-tendermint-23-109.json
+++ b/testnets/xion-testnet-1/governance-proposals/ibc-client-update/proposal/07-tendermint-23-109.json
@@ -1,0 +1,13 @@
+{
+  "messages": [
+    {
+      "@type": "/ibc.core.client.v1.ClientUpdateProposal",
+      "title": "Update IBC client 07-tendermint-23 -> 07-tendermint-109",
+      "description": "Update IBC client 07-tendermint-23 -> 07-tendermint-109",
+      "subject_client_id": "07-tendermint-23",
+      "substitute_client_id": "07-tendermint-109"
+    }
+  ],
+  "metadata": "https://raw.githubusercontent.com/burnt-labs/burnt-networks/main/testnets/xion-testnet-1/governance-proposals/ibc-client-updates/metadata/07-tendermint-23-109.json",
+  "deposit": "10000000uxion"
+}


### PR DESCRIPTION
## Description

Govprops to update `xion-testnet-1` <=> `osmo-test-5` IBC clients for `transfer` and `feeabs`

## Type of Change

- [ ] New Validator
- [x] Governance Proposal
- [ ] Bug fix
- [ ] Documentation update
- [ ] Tooling enhancement

## Testing

- [x] I've read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [ ] I ran `make validate-genesis`
- [ ] I ran `make verify-hashes`

## Additional Information

Any additional information that you want to provide.

## Reviewers:

/assign @froch

Thank you for supporting the Burnt Networks!
