### PR TITLE
xion-testnet-1 // allow CosmWasm codeID for x/abstractaccount

### DIFF
--- a/testnets/xion-testnet-1/governance-proposals/update-parameters/metadata/005-abstract-account-set-allowed-code-ids.json
+++ b/testnets/xion-testnet-1/governance-proposals/update-parameters/metadata/005-abstract-account-set-allowed-code-ids.json
@@ -1,0 +1,10 @@
+{
+  "title": "Allow specific wasm codeIDs for x/abstractaccount",
+  "authors": [
+    "daemon@burnt.com"
+  ],
+  "summary": "Allow specific wasm codeIDs for x/abstractaccount",
+  "details": "Allow specific wasm codeIDs for x/abstractaccount",
+  "proposal_forum_url": "",
+  "vote_option_context": ""
+}

--- a/testnets/xion-testnet-1/governance-proposals/update-parameters/proposal/005-abstract-account-set-allowed-code-ids.json
+++ b/testnets/xion-testnet-1/governance-proposals/update-parameters/proposal/005-abstract-account-set-allowed-code-ids.json
@@ -1,0 +1,18 @@
+{
+  "messages": [
+    {
+      "@type": "/abstractaccount.v1.MsgUpdateParams",
+      "sender": "xion10d07y265gmmuvt4z0w9aw880jnsr700jctf8qc",
+      "params": {
+        "allow_all_code_ids": false,
+        "allowed_code_ids": [21],
+        "max_gas_before": "5000000",
+        "max_gas_after": "5000000"
+      }
+    }
+  ],
+  "metadata": "https://raw.githubusercontent.com/burnt-labs/burnt-networks/main/testnets/xion-testnet-1/governance-proposals/update-parameters/metadata/005-abstract-account-set-allowed-code-ids.json",
+  "deposit": "10000000uxion",
+  "title": "Allow specific wasm codeIDs for x/abstractaccount",
+  "summary": "Allow specific wasm codeIDs for x/abstractaccount"
+}


### PR DESCRIPTION
## Description

Allow CosmWasm contract CodeID for use by x/abstractaccount

## Type of Change

- [ ] New Validator
- [x] Governance Proposal
- [ ] Bug fix
- [ ] Documentation update
- [ ] Tooling enhancement

## Testing

- [x] I've read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I ran `make validate-genesis`
- [x] I ran `make verify-hashes`

## Additional Information

Any additional information that you want to provide.

## Reviewers:

/assign @froch

Thank you for supporting the Burnt Networks!
