### PR TITLE
xion-mainnet-1 / software upgrade v7.0.0

### DIFF
--- a/mainnet/xion-mainnet-1/governance-proposals/software-upgrades/binaries/v7.0.0.json
+++ b/mainnet/xion-mainnet-1/governance-proposals/software-upgrades/binaries/v7.0.0.json
@@ -1,0 +1,5 @@
+{
+  "binaries": {
+    "linux/amd64": "https://github.com/burnt-labs/xion/releases/download/v7.0.0/xiond-v7.0.0-linux-amd64"
+  }
+}

--- a/mainnet/xion-mainnet-1/governance-proposals/software-upgrades/metadata/v0.3.9.json
+++ b/mainnet/xion-mainnet-1/governance-proposals/software-upgrades/metadata/v0.3.9.json
@@ -1,0 +1,10 @@
+{
+  "title": "Software upgrade v0.3.9",
+  "authors": [
+    "daemon@burnt.com"
+  ],
+  "summary": "Software upgrade v0.3.9",
+  "details": "UUpgrade to v0.3.9 at block height 606689; burntnetwork/xion:0.3.9",
+  "proposal_forum_url": "",
+  "vote_option_context": ""
+}

--- a/mainnet/xion-mainnet-1/governance-proposals/software-upgrades/metadata/v7.0.0.json
+++ b/mainnet/xion-mainnet-1/governance-proposals/software-upgrades/metadata/v7.0.0.json
@@ -1,0 +1,10 @@
+{
+  "title": "Software upgrade v7.0.0",
+  "authors": [
+    "daemon@burnt.com"
+  ],
+  "summary": "Software upgrade v7.0.0",
+  "details": "Upgrade to v7.0.0 at block height 1637000; burntnetwork/xion:7.0.0",
+  "proposal_forum_url": "",
+  "vote_option_context": ""
+}

--- a/mainnet/xion-mainnet-1/governance-proposals/software-upgrades/proposal/v0.3.9.json
+++ b/mainnet/xion-mainnet-1/governance-proposals/software-upgrades/proposal/v0.3.9.json
@@ -1,0 +1,18 @@
+{
+  "messages": [
+    {
+      "@type": "/cosmos.upgrade.v1beta1.MsgSoftwareUpgrade",
+      "authority": "xion10d07y265gmmuvt4z0w9aw880jnsr700jctf8qc",
+      "plan": {
+        "name": "v6",
+        "height": "606689",
+        "info": "Upgrade to v0.3.9 at block height 606689; burntnetwork/xion:0.3.9",
+        "upgraded_client_state": null
+      }
+    }
+  ],
+  "metadata": "https://raw.githubusercontent.com/burnt-labs/burnt-networks/main/mainnet/xion-mainnet-1/governance-proposals/software-upgrades/metadata/v0.3.9.json",
+  "deposit": "10000000uxion",
+  "title": "Software Upgrade v0.3.9",
+  "summary": "Software Upgrade v0.3.9"
+}

--- a/mainnet/xion-mainnet-1/governance-proposals/software-upgrades/proposal/v7.0.0.json
+++ b/mainnet/xion-mainnet-1/governance-proposals/software-upgrades/proposal/v7.0.0.json
@@ -1,0 +1,18 @@
+{
+  "messages": [
+    {
+      "@type": "/cosmos.upgrade.v1beta1.MsgSoftwareUpgrade",
+      "authority": "xion10d07y265gmmuvt4z0w9aw880jnsr700jctf8qc",
+      "plan": {
+        "name": "v7.0.0",
+        "height": "1637000",
+        "info": "https://raw.githubusercontent.com/burnt-labs/burnt-networks/main/mainnet/xion-mainnet-1/governance-proposals/software-upgrades/binaries/v7.0.0.json",
+        "upgraded_client_state": null
+      }
+    }
+  ],
+  "metadata": "https://raw.githubusercontent.com/burnt-labs/burnt-networks/main/mainnet/xion-mainnet-1/governance-proposals/software-upgrades/metadata/v7.0.0.json",
+  "deposit": "10000000uxion",
+  "title": "Software Upgrade v7.0.0",
+  "summary": "Software Upgrade v7.0.0"
+}


### PR DESCRIPTION
## Description

mainnet xiond upgrade v7.0.0

## Type of Change

- [ ] New Validator
- [x] Governance Proposal
- [ ] Bug fix
- [ ] Documentation update
- [ ] Tooling enhancement

## Testing

- [x] I've read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [ ] I ran `make validate-genesis`
- [ ] I ran `make verify-hashes`

## Reviewers:

/assign @froch

Thank you for supporting the Burnt Networks!
