### PR TITLE
Update PULL_REQUEST_TEMPLATE.md

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -18,7 +18,7 @@ Please include a detailed description of the changes being proposed in this pull
 
 ## Testing
 
-- [ ] I've read [CONTRIBUTING.md](../CONTRIBUTING.md)
+- [ ] I've read [CONTRIBUTING.md](./CONTRIBUTING.md)
 
 ## Additional Information
 


### PR DESCRIPTION
Fix CONTRIBUTING.md link in PR template

The link would previously navigate to `https://github.com/burnt-labs/burnt-networks/CONTRIBUTING.md`, hopefully this works.

## Description

Please include a detailed description of the changes being proposed in this pull request.

**Validators:**
- Who are you
- Nature and content of your gentx

## Type of Change

- [ ] Governance Proposal
- [ ] Software Upgrade
- [ ] Parameter Change
- [ ] New Validator
- [ ] Bug fix
- [ ] Documentation update
- [ ] Tooling enhancement

## Testing

- [ ] I've read [CONTRIBUTING.md](../CONTRIBUTING.md)

## Additional Information

Any additional context that you want to provide.

## Reviewers:

/assign @froch
/assign @2xburnt

Thank you for supporting the Burnt Networks!
