### PR TITLE
Replaced abstract 0.26 code id to work with instantiate

### DIFF
--- a/testnets/xion-testnet-1/governance-proposals/update-parameters/metadata/018-abstract-account-set-allowed-code-ids.json
+++ b/testnets/xion-testnet-1/governance-proposals/update-parameters/metadata/018-abstract-account-set-allowed-code-ids.json
@@ -1,0 +1,10 @@
+{
+    "title": "Add new account code id",
+    "authors": [
+        "nicolas@abstract.money"
+    ],
+    "summary": "Change registered Code Id to be able to instantiate new accounts using instantiate and reduce the XION API changes",
+    "details": "add new account code id",
+    "proposal_forum_url": "nil",
+    "vote_option_context": "yes to accept, no to deny"
+}

--- a/testnets/xion-testnet-1/governance-proposals/update-parameters/proposal/018-abstract-account-set-allowed-code-ids.json
+++ b/testnets/xion-testnet-1/governance-proposals/update-parameters/proposal/018-abstract-account-set-allowed-code-ids.json
@@ -1,0 +1,23 @@
+{
+    "messages": [
+        {
+            "@type": "/abstractaccount.v1.MsgUpdateParams",
+            "sender": "xion10d07y265gmmuvt4z0w9aw880jnsr700jctf8qc",
+            "params": {
+                "allow_all_code_ids": false,
+                "allowed_code_ids": [
+                    21,
+                    793,
+                    1986
+                ],
+                "max_gas_before": "5000000",
+                "max_gas_after": "5000000"
+            }
+        }
+    ],
+    "metadata": "https://raw.githubusercontent.com/burnt-labs/burnt-networks/main/testnets/xion-testnet-1/governance-proposals/update-parameters/metadata/017-abstract-account-set-allowed-code-ids.json",
+    "deposit": "1000000000uxion",
+    "title": "add new account code id",
+    "summary": "add new account code id",
+    "expedited": true
+}


### PR DESCRIPTION
## Description

Please include a detailed description of the changes being proposed in this pull request.

I'm the Smart Contracts lead at Abstract SDK
We uploaded our latest Abstract SDK account code-id. This is the result of the adaptation of Abstract to XION accounts AND the stabilisation of the framework. We replace the old id (1986) which fails to instantiate new accounts with instantiate add the new code id (1659) that needs to be used going forward.

## Type of Change

- [x] Governance Proposal
- [ ] Software Upgrade
- [x] Parameter Change
- [ ] Contract Upload
- [ ] New Validator
- [ ] Bug fix
- [ ] Documentation update
- [ ] Tooling enhancement
- [x] Replace Abstract Account Contract

## Testing

- [ ] I've read [CONTRIBUTING.md](./CONTRIBUTING.md)

## Additional Information

Any additional context that you want to provide.

## Reviewers:

/assign @2xburnt
/assign @ash-burnt

Thank you for supporting the Burnt Networks!
